### PR TITLE
Add health check to the Dockerfile for use outside ECS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ LABEL maintainer="Dwolla Dev <dev+dwolla-adot-collector@dwolla.com>"
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/dwolla-adot-collector"
 
 COPY otel-config.yaml /etc/otel-config.yaml
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=60s --start-interval=5s \
+  CMD /healthcheck


### PR DESCRIPTION
This health check isn't used by ECS, but it matches the settings I expect to use there. It would be used locally if the container is started by Docker Compose, for example.