### PR TITLE
Add transform and linkextractor processors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-# Use Go 1.23 to match the builder's era and avoid Go 1.24 strictness issues
-FROM golang:1.23-alpine AS builder
+# Use Go 1.24 to satisfy builder v0.141.0 toolchain requirement
+FROM golang:1.24-alpine AS builder
 
 # Install build dependencies
 RUN apk --update add ca-certificates git
 
-# Install the builder tool v0.111.0
-RUN go install go.opentelemetry.io/collector/cmd/builder@v0.111.0
+# Install the builder tool v0.141.0
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.141.0
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,48 @@
-ARG OTEL_TAG
-FROM amazon/aws-otel-collector:${OTEL_TAG}
+# Use Go 1.23 to match the builder's era and avoid Go 1.24 strictness issues
+FROM golang:1.23-alpine AS builder
+
+# Install build dependencies
+RUN apk --update add ca-certificates git
+
+# Install the builder tool v0.111.0
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.111.0
+
+WORKDIR /build
+
+# Copy the config AND the local source code
+COPY builder-config.yaml .
+COPY healthchecker.go .
+COPY pkg ./pkg  
+
+# Generate the source code and build the binary
+RUN builder --config builder-config.yaml
+
+# Build the healthcheck utility
+RUN go build -o /build/dist/healthcheck healthchecker.go
+
+# Stage 2: Final Image
+FROM gcr.io/distroless/static:latest
 LABEL maintainer="Dwolla Dev <dev+dwolla-adot-collector@dwolla.com>"
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/dwolla-adot-collector"
 
-COPY otel-config.yaml /etc/otel-config.yaml
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=60s --start-interval=5s \
-  CMD /healthcheck
+# Switch to non-root user for security
+USER nonroot:nonroot
+
+COPY --from=builder --chown=nonroot:nonroot /build/dist/otelcol-custom /otelcol-custom
+COPY --from=builder --chown=nonroot:nonroot /build/dist/healthcheck /healthcheck
+
+# Expose standard OTLP ports
+EXPOSE 4317 4318 13133
+
+COPY --chown=nonroot:nonroot otel-config.yaml /etc/otel-config.yaml
+
+HEALTHCHECK \
+  --interval=30s \
+  --timeout=5s \
+  --retries=3 \
+  --start-period=60s \
+  --start-interval=5s \
+  CMD ["/healthcheck"]
+
+ENTRYPOINT ["/otelcol-custom"]
+CMD ["--config", "/etc/otel-config.yaml"]

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
-OTEL_TAG := $(OTEL_TAG)
-JOB := core-${OTEL_TAG}
-CLEAN_JOB := clean-${OTEL_TAG}
+# Default to loading into local docker daemon. Override with --push for remote.
+OUTPUT ?= --load
+# Default to empty to let Docker pick the local platform. Override for multi-arch.
+PLATFORM ?= 
 
-all: ${JOB}
-clean: ${CLEAN_JOB}
-.PHONY: all clean ${JOB} ${CLEAN_JOB}
+all: core
+clean: clean-core
+.PHONY: all clean core clean-core
 
-${JOB}: core-%: Dockerfile
+core: Dockerfile
 	docker buildx build \
-	  --platform linux/arm64,linux/amd64 \
-	  --build-arg OTEL_TAG=$* \
-	  --tag dwolla/otel-collector:$*-SNAPSHOT \
+	  $(OUTPUT) \
+	  $(if $(PLATFORM),--platform $(PLATFORM),) \
+	  --tag dwolla/otel-collector:latest \
 	  .
 
-${CLEAN_JOB}: clean-%:
-	docker image rm --force dwolla/otel-collector:$*-SNAPSHOT
+clean-core:
+	-docker image rm --force dwolla/otel-collector:latest

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -8,50 +8,50 @@ dist:
     file: healthcheck
 
 exporters:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.141.0
   # Core components
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.111.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.111.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.111.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.141.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.141.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.141.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.111.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.141.0
 
 processors:
   # Your local processor
   - gomod: github.com/dwolla/dwolla-adot-collector/pkg/processor/linkprocessor v0.0.0
     path: ./pkg/processor/linkprocessor
 
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.111.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.111.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.141.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.141.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.141.0
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.111.0
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.141.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.141.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.141.0
 
 replaces:
-  - "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray => github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray v0.111.0"
+  - "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray => github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray v0.141.0"

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -1,0 +1,57 @@
+dist:
+  name: otelcol-custom
+  description: "Custom ADOT-compatible Collector with Transform Processor"
+  output_path: ./dist
+  # otelcol_version REMOVED
+  health_check:
+    enabled: true
+    file: healthcheck
+
+exporters:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.111.0
+  # Core components
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.111.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.111.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.111.0
+
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.111.0
+
+processors:
+  # Your local processor
+  - gomod: github.com/dwolla/dwolla-adot-collector/pkg/processor/linkprocessor v0.0.0
+    path: ./pkg/processor/linkprocessor
+
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.111.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.111.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.111.0
+
+extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.111.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.111.0
+
+replaces:
+  - "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray => github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray v0.111.0"

--- a/healthchecker.go
+++ b/healthchecker.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	// The port the OpenTelemetry Collector's health_check extension is listening on
+	const healthCheckURL = "http://localhost:13133"
+
+	client := http.Client{
+		Timeout: 5 * time.Second, // Set a timeout
+	}
+
+	resp, err := client.Get(healthCheckURL)
+	if err != nil {
+		fmt.Printf("Health check failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Health check failed with status code: %d\n", resp.StatusCode)
+		os.Exit(1)
+	}
+
+	fmt.Println("Health check successful")
+	os.Exit(0) // Success
+}

--- a/otel-config.yaml
+++ b/otel-config.yaml
@@ -1,5 +1,6 @@
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
 
 receivers:
   otlp:
@@ -22,21 +23,26 @@ processors:
       - key: deployment.environment.name
         value: ${env:DWOLLA_ENV}
         action: insert
-      - key: peer.service
-        action: extract
-        pattern: ^consul!(?P<peerservice>.*)$    # AFAICT using "peer.service" would be an illegal capture group name
-      - key: peer.service
-        action: update
-        from_attribute: peerservice
-      - key: peerservice
-        action: delete
-      - key: http.status_code # this is deprecated but X-Ray wants it; see https://aws-otel.github.io/docs/getting-started/x-ray#otel-span-http-attributes-translation
+      - key: http.status_code # this is deprecated, but X-Ray wants it; see https://aws-otel.github.io/docs/getting-started/x-ray#otel-span-http-attributes-translation
         action: insert
         from_attribute: http.response.status_code
+  transform/replace-exclamation-with-colon:
+    trace_statements:
+      - context: span
+        statements:
+          - replace_pattern(attributes["peer.service"], "!", ":")
+  linkextractor:
+    attribute_name: "linked_trace_ids"
+  transform/flatten-linked-trace-ids:
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["linked_trace_ids"], String(attributes["linked_trace_ids"]))
 
 exporters:
   awsxray:
     indexed_attributes: # see https://github.com/Dwolla/dwolla-otel-natchez/blob/dc1aa448d97a91f50ec52653b3e28d7fbf147f87/dwolla-xray-annotations/src/test/scala/com/dwolla/tracing/XRayAnnotationsSpec.scala#L27-L33
+      - linked_trace_ids
       - deployment.environment.name
       - otel.resource.deployment.environment.name
       - otel.resource.service.name
@@ -55,6 +61,9 @@ service:
         - memory_limiter
         - batch/traces
         - attributes
+        - transform/replace-exclamation-with-colon
+        - linkextractor
+        - transform/flatten-linked-trace-ids
       exporters:
         - awsxray
 

--- a/pkg/processor/linkprocessor/config.go
+++ b/pkg/processor/linkprocessor/config.go
@@ -1,0 +1,14 @@
+package linkprocessor
+
+import "go.opentelemetry.io/collector/component"
+
+type Config struct {
+	// AttributeName is the name of the attribute to set. Defaults to "linked_trace_ids".
+	AttributeName string `mapstructure:"attribute_name"`
+}
+
+var _ component.Config = (*Config)(nil)
+
+func (c *Config) Validate() error {
+	return nil
+}

--- a/pkg/processor/linkprocessor/factory.go
+++ b/pkg/processor/linkprocessor/factory.go
@@ -1,0 +1,37 @@
+package linkprocessor
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor"
+)
+
+var (
+	typeStr = component.MustNewType("linkextractor")
+)
+
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		processor.WithTraces(createTracesProcessor, component.StabilityLevelDevelopment),
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{
+		AttributeName: "linked_trace_ids",
+	}
+}
+
+func createTracesProcessor(
+	_ context.Context,
+	set processor.Settings,
+	cfg component.Config,
+	nextConsumer consumer.Traces,
+) (processor.Traces, error) {
+	processorConfig := cfg.(*Config)
+	return newLinkProcessor(processorConfig, set.Logger, nextConsumer)
+}

--- a/pkg/processor/linkprocessor/factory.go
+++ b/pkg/processor/linkprocessor/factory.go
@@ -33,5 +33,5 @@ func createTracesProcessor(
 	nextConsumer consumer.Traces,
 ) (processor.Traces, error) {
 	processorConfig := cfg.(*Config)
-	return newLinkProcessor(processorConfig, set.Logger, nextConsumer)
+	return newLinkProcessor(processorConfig, nextConsumer)
 }

--- a/pkg/processor/linkprocessor/go.mod
+++ b/pkg/processor/linkprocessor/go.mod
@@ -1,11 +1,10 @@
 module github.com/dwolla/dwolla-adot-collector/pkg/processor/linkprocessor
 
-go 1.22
+go 1.23
 
 require (
-	go.opentelemetry.io/collector/component v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.0
-	go.opentelemetry.io/collector/pdata v1.17.0
-	go.opentelemetry.io/collector/processor v0.111.0
-	go.uber.org/zap v1.27.0
+    go.opentelemetry.io/collector/component v0.141.0
+    go.opentelemetry.io/collector/consumer v0.141.0
+    go.opentelemetry.io/collector/processor v0.141.0
+    go.uber.org/zap v1.27.0
 )

--- a/pkg/processor/linkprocessor/go.mod
+++ b/pkg/processor/linkprocessor/go.mod
@@ -1,0 +1,11 @@
+module github.com/dwolla/dwolla-adot-collector/pkg/processor/linkprocessor
+
+go 1.22
+
+require (
+	go.opentelemetry.io/collector/component v0.111.0
+	go.opentelemetry.io/collector/consumer v0.111.0
+	go.opentelemetry.io/collector/pdata v1.17.0
+	go.opentelemetry.io/collector/processor v0.111.0
+	go.uber.org/zap v1.27.0
+)

--- a/pkg/processor/linkprocessor/processor.go
+++ b/pkg/processor/linkprocessor/processor.go
@@ -8,18 +8,15 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
-	"go.uber.org/zap"
 )
 
 type linkProcessor struct {
-	logger        *zap.Logger
 	nextConsumer  consumer.Traces
 	attributeName string
 }
 
-func newLinkProcessor(cfg *Config, logger *zap.Logger, next consumer.Traces) (processor.Traces, error) {
+func newLinkProcessor(cfg *Config, next consumer.Traces) (processor.Traces, error) {
 	return &linkProcessor{
-		logger:        logger,
 		nextConsumer:  next,
 		attributeName: cfg.AttributeName,
 	}, nil

--- a/pkg/processor/linkprocessor/processor.go
+++ b/pkg/processor/linkprocessor/processor.go
@@ -1,0 +1,76 @@
+package linkprocessor
+
+import (
+	"context"
+	"encoding/hex"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+)
+
+type linkProcessor struct {
+	logger        *zap.Logger
+	nextConsumer  consumer.Traces
+	attributeName string
+}
+
+func newLinkProcessor(cfg *Config, logger *zap.Logger, next consumer.Traces) (processor.Traces, error) {
+	return &linkProcessor{
+		logger:        logger,
+		nextConsumer:  next,
+		attributeName: cfg.AttributeName,
+	}, nil
+}
+
+func (p *linkProcessor) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		rs := rss.At(i)
+		ilss := rs.ScopeSpans()
+		for j := 0; j < ilss.Len(); j++ {
+			ils := ilss.At(j)
+			spans := ils.Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				p.processSpan(span)
+			}
+		}
+	}
+	return p.nextConsumer.ConsumeTraces(ctx, td)
+}
+
+func (p *linkProcessor) processSpan(span ptrace.Span) {
+	links := span.Links()
+	if links.Len() == 0 {
+		return
+	}
+
+	// Create a new slice in the attributes map directly
+	// pdata v1.x uses PutEmptySlice which returns the slice to be filled
+	traceIDs := span.Attributes().PutEmptySlice(p.attributeName)
+	// Ensure capacity
+	traceIDs.EnsureCapacity(links.Len())
+	
+	for i := 0; i < links.Len(); i++ {
+		link := links.At(i)
+		traceID := link.TraceID()
+		// Convert [16]byte TraceID to hex string
+		hexID := hex.EncodeToString(traceID[:])
+		traceIDs.AppendEmpty().SetStr(hexID)
+	}
+}
+
+func (p *linkProcessor) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+func (p *linkProcessor) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (p *linkProcessor) Shutdown(_ context.Context) error {
+	return nil
+}


### PR DESCRIPTION
This acts like the AWS Distribution of OpenTelemetry in that it has the AWS plugins installed, but it also adds the `transform` processor (which we can use to more efficiently `replace_pattern(attributes["peer.service"], "!", ":")`) and the `linkextractor` processor (which copies linked trace IDs from `span.links` to the span's attributes list, so that they can be surfaced in X-Ray, which doesn't support linked traces natively.