### PR TITLE
rename attributes added by natchez-http4s to follow OTel semantic conventions

### DIFF
--- a/otel-config.yaml
+++ b/otel-config.yaml
@@ -23,6 +23,35 @@ processors:
       - key: deployment.environment.name
         value: ${env:DWOLLA_ENV}
         action: insert
+
+  # rename attributes to follow OTel semantic conventions
+      - key: url.full
+        action: insert
+        # from https://github.com/typelevel/natchez-http4s/blob/168f5031323a573b5641f43c74a25d1a996f7b61/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala#L176
+        from_attribute: client.http.uri
+      - key: http.request.method
+        action: insert
+        # from https://github.com/typelevel/natchez-http4s/blob/168f5031323a573b5641f43c74a25d1a996f7b61/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala#L177
+        from_attribute: client.http.method
+      - key: http.response.status_code
+        action: insert
+        # from https://github.com/typelevel/natchez-http4s/blob/168f5031323a573b5641f43c74a25d1a996f7b61/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala#L183
+        from_attribute: client.http.status_code
+      - key: http.response.status_code
+        action: insert
+        # from https://github.com/typelevel/natchez-http4s/blob/168f5031323a573b5641f43c74a25d1a996f7b61/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala#L58
+        from_attribute: http.status_code
+  # remove the attributes we copied to complete the renaming
+      - action: delete
+        pattern: client\.http\.uri|client\.http\.method|(?:client\.)?http\.status_code
+  transform/status-code-is-int:
+    # Natchez-http4s sets http.response.status_code as a string, but the OTel semantic
+    # conventions define it as an int, and X-Ray won't display it otherwise.
+    # see https://github.com/typelevel/natchez-http4s/blob/168f5031323a573b5641f43c74a25d1a996f7b61/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala#L183
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["http.response.status_code"], Int(attributes["http.response.status_code"]))
   transform/replace-exclamation-with-colon:
     trace_statements:
       - context: span

--- a/otel-config.yaml
+++ b/otel-config.yaml
@@ -23,9 +23,6 @@ processors:
       - key: deployment.environment.name
         value: ${env:DWOLLA_ENV}
         action: insert
-      - key: http.status_code # this is deprecated, but X-Ray wants it; see https://aws-otel.github.io/docs/getting-started/x-ray#otel-span-http-attributes-translation
-        action: insert
-        from_attribute: http.response.status_code
   transform/replace-exclamation-with-colon:
     trace_statements:
       - context: span


### PR DESCRIPTION
Following standards is generally a good thing, but especially here, because with these changes, X-Ray should start displaying a lot more useful information in its UI: (highlighted in orange)
<img width="1423" height="502" alt="Screenshot 2025-12-18 at 5 50 28 PM" src="https://github.com/user-attachments/assets/6e847265-eb12-4dd8-9bab-4eec0fb4a3ac" />

The trace map is also improved, showing the correct association from client to server:
<img width="927" height="226" alt="image" src="https://github.com/user-attachments/assets/bb85334b-043b-47ff-a902-c75f2675a0bd" />

Some of this may be able to be removed if https://github.com/typelevel/natchez-http4s/pull/148 is merged.